### PR TITLE
Fix for PSR bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
 
       - run: composer install --no-progress
 
-      - run: bash build.sh dev
+      - run: vendor/bin/php-scoper add-prefix --output-dir=build --force
+      - run: rm -rf vendor/psr/container vendor/inpsyde/modularity
+      - run: cp -r build/psr/container vendor/psr/container
+      - run: cp -r build/inpsyde/modularity vendor/inpsyde/modularity
+      - run: rm -rf build
 
       - run: composer phpcs
       - run: composer phpstan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - run: composer install --no-progress
 
+      - run: bash build.sh dev
+
       - run: composer phpcs
       - run: composer phpstan
       - run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run: cp -r build/psr/container vendor/psr/container
       - run: cp -r build/inpsyde/modularity vendor/inpsyde/modularity
       - run: rm -rf build
+      - run: composer dump-autoload
 
       - run: composer phpcs
       - run: composer phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ Thumbs.db
 .phpcs-cache
 node_modules/
 build/
+unique-headers.zip
 assets/admin.js

--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ If you would like to pay for assistance, additional features to be added to the 
 
 ## Changelog
 
+### 2.1 - 2026-05-07
+
+* Fixed PSR-4 container namespacing bug
+
 ### 2.0.1 - 2026-05-01
 
 * CI: restricted PHP version matrix to 8.4 and 8.5

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Unique Headers
 
-Adds the ability to use unique custom header images on individual pages, posts or categories or tags.
-
-This plugin has been actively maintained since 2012 and is used on over 20,000 websites worldwide.
+Add unique custom header images to individual pages, posts, categories, or tags.
 
 
 ## Installation
@@ -166,6 +164,8 @@ All PHP code uses `declare(strict_types=1)` and follows PSR-12.
 
 ## Description
 
+This plugin has been actively maintained since 2012 and is used on over 20,000 websites worldwide.
+
 ### Features
 
 The <a href="https://geek.hellyer.kiwi/products/unique-headers/">Unique Headers Plugin</a> adds a custom header image box to the post/page edit screen. You can use this to upload a unique header image for that post, or use another image from your WordPress media library. When you view that page on the front-end of your site, the default header image for your site will be replaced by the unique header you selected.
@@ -197,6 +197,11 @@ If you would like to pay for assistance, additional features to be added to the 
 
 
 ## Changelog
+
+### 2.1.1 - 2026-05-07
+
+* Fixing version number
+* Shortening readme description to meet WordPress.org requirements
 
 ### 2.1 - 2026-05-07
 

--- a/build.sh
+++ b/build.sh
@@ -97,6 +97,7 @@ if [ "$MODE" = "prod" ]; then
 
 spl_autoload_register(static function (string $class): void {
     $prefixes = [
+        'RyanHellyer\\UniqueHeaders\\' => __DIR__ . '/../src/',
         'RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\' => __DIR__ . '/psr/container/src/',
         'RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\' => __DIR__ . '/inpsyde/modularity/src/',
     ];

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -eq 1 ]; then
+    CHOICE="$1"
+else
+    echo "Select build mode:"
+    echo "  1) Dev - build scoped deps into vendor/"
+    echo "  2) Prod - build scoped deps, create zip, cleanup"
+    read -rp "Choice [1-2]: " CHOICE
+fi
+
+case "$CHOICE" in
+    1|dev) MODE="dev" ;;
+    2|prod) MODE="prod" ;;
+    *) echo "Invalid choice"; exit 1 ;;
+esac
+
+echo "=== Mode: $MODE ==="
+
+echo "=== Ensuring dependencies are installed ==="
+rm -rf vendor
+composer install
+
+echo "=== Generating README.md ==="
+composer generate-readme 2>/dev/null || true
+
+echo "=== Cleaning build directory ==="
+rm -rf build
+
+echo "=== Running PHP-Scoper ==="
+PHP_SCOPER="$(command -v php-scoper || echo './vendor/bin/php-scoper')"
+$PHP_SCOPER add-prefix --output-dir=build --force
+
+echo "=== Replacing vendor files with scoped versions ==="
+rm -rf vendor/psr/container
+rm -rf vendor/inpsyde/modularity
+cp -r build/psr/container vendor/psr/container
+cp -r build/inpsyde/modularity vendor/inpsyde/modularity
+
+echo "=== Generating autoloader ==="
+SCOPED_AUTOLOADER=$(cat << 'AUTOLOAD'
+
+spl_autoload_register(static function (string $class): void {
+    $prefixes = [
+        'RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\' => __DIR__ . '/psr/container/src/',
+        'RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\' => __DIR__ . '/inpsyde/modularity/src/',
+    ];
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) !== 0) {
+            continue;
+        }
+        $file = $baseDir . str_replace('\\', '/', substr($class, $len)) . '.php';
+        if (file_exists($file)) {
+            require $file;
+            return;
+        }
+    }
+});
+AUTOLOAD
+)
+
+COMPOSER_INIT=$(grep -oP 'ComposerAutoloaderInit\w+' vendor/autoload.php | head -1)
+
+cat > vendor/autoload.php << AUTOLOAD
+<?php
+
+require_once __DIR__ . '/composer/autoload_real.php';
+${COMPOSER_INIT}::getLoader();
+
+${SCOPED_AUTOLOADER}
+AUTOLOAD
+
+echo "=== Cleaning up build directory ==="
+rm -rf build
+
+if [ "$MODE" = "prod" ]; then
+    echo "=== Creating production zip ==="
+
+    PLUGIN_DIR="build/plugin"
+    mkdir -p "$PLUGIN_DIR"
+
+    cp index.php "$PLUGIN_DIR/"
+    cp readme.txt "$PLUGIN_DIR/" 2>/dev/null || true
+    cp license.txt "$PLUGIN_DIR/" 2>/dev/null || true
+    cp -r src "$PLUGIN_DIR/"
+    cp -r assets "$PLUGIN_DIR/"
+    cp -r languages "$PLUGIN_DIR/"
+    cp -r views "$PLUGIN_DIR/"
+
+    mkdir -p "$PLUGIN_DIR/vendor"
+
+    # Write a standalone autoloader for the zip (no Composer dependency)
+    cat > "$PLUGIN_DIR/vendor/autoload.php" << 'AUTOLOAD'
+<?php
+
+spl_autoload_register(static function (string $class): void {
+    $prefixes = [
+        'RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\' => __DIR__ . '/psr/container/src/',
+        'RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\' => __DIR__ . '/inpsyde/modularity/src/',
+    ];
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($prefix, $class, $len) !== 0) {
+            continue;
+        }
+        $file = $baseDir . str_replace('\\', '/', substr($class, $len)) . '.php';
+        if (file_exists($file)) {
+            require $file;
+            return;
+        }
+    }
+});
+AUTOLOAD
+
+    mkdir -p "$PLUGIN_DIR/vendor/psr"
+    mkdir -p "$PLUGIN_DIR/vendor/inpsyde"
+    cp -r vendor/psr/container "$PLUGIN_DIR/vendor/psr/container"
+    cp -r vendor/inpsyde/modularity "$PLUGIN_DIR/vendor/inpsyde/modularity"
+
+    cd "$PLUGIN_DIR"
+    zip -r ../../unique-headers.zip . -x ".*"
+    cd ../../
+
+    echo "=== Cleaning up ==="
+    rm -rf build
+
+    echo "=== Production zip created: unique-headers.zip ==="
+    exit 0
+fi
+
+echo "=== Dev build complete ==="
+echo "vendor/ now has scoped dependencies."
+echo "Run 'composer install' to restore original dev dependencies."

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,7 @@ spl_autoload_register(static function (string $class): void {
     $prefixes = [
         'RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\' => __DIR__ . '/psr/container/src/',
         'RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\' => __DIR__ . '/inpsyde/modularity/src/',
+        'RyanHellyer\\UniqueHeaders\\' => __DIR__ . '/../src/',
     ];
     foreach ($prefixes as $prefix => $baseDir) {
         $len = strlen($prefix);
@@ -89,17 +90,17 @@ if [ "$MODE" = "prod" ]; then
     cp -r languages "$PLUGIN_DIR/"
     cp -r views "$PLUGIN_DIR/"
 
+    # Write a standalone autoloader for the zip (no Composer dependency)
     mkdir -p "$PLUGIN_DIR/vendor"
 
-    # Write a standalone autoloader for the zip (no Composer dependency)
-    cat > "$PLUGIN_DIR/vendor/autoload.php" << 'AUTOLOAD'
+    cat > "$PLUGIN_DIR/vendor/autoload.php" << 'PHP'
 <?php
 
 spl_autoload_register(static function (string $class): void {
     $prefixes = [
-        'RyanHellyer\\UniqueHeaders\\' => __DIR__ . '/../src/',
         'RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\' => __DIR__ . '/psr/container/src/',
         'RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\' => __DIR__ . '/inpsyde/modularity/src/',
+        'RyanHellyer\\UniqueHeaders\\' => __DIR__ . '/../src/',
     ];
     foreach ($prefixes as $prefix => $baseDir) {
         $len = strlen($prefix);
@@ -113,7 +114,7 @@ spl_autoload_register(static function (string $class): void {
         }
     }
 });
-AUTOLOAD
+PHP
 
     mkdir -p "$PLUGIN_DIR/vendor/psr"
     mkdir -p "$PLUGIN_DIR/vendor/inpsyde"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "squizlabs/php_codesniffer": "^4.0",
         "phpunit/phpunit": "^13.1",
-        "wpreadme2markdown/wpreadme2markdown": "^4.1"
+        "wpreadme2markdown/wpreadme2markdown": "^4.1",
+        "humbug/php-scoper": "^0.18"
     },
     "scripts": {
         "phpcs": "phpcs --report=full -s && echo \"No violations found.\"",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
     },
     "autoload": {
         "psr-4": {
-            "RyanHellyer\\UniqueHeaders\\": "src/"
+            "RyanHellyer\\UniqueHeaders\\": "src/",
+            "RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\": "vendor/psr/container/src/",
+            "RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\": "vendor/inpsyde/modularity/src/"
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ Description: Unique Headers
 Version: 2.0.1
 Author: Ryan Hellyer
 Author URI: https://geek.hellyer.kiwi/
-License: GPL2
+License: GPLv2 or later
 
 ------------------------------------------------------------------------
 Copyright Ryan Hellyer

--- a/index.php
+++ b/index.php
@@ -30,8 +30,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 declare(strict_types=1);
 
-use Inpsyde\Modularity\Package;
-use Inpsyde\Modularity\Properties\PluginProperties;
+use RyanHellyer\UniqueHeaders\Vendor\Inpsyde\Modularity\Package;
+use RyanHellyer\UniqueHeaders\Vendor\Inpsyde\Modularity\Properties\PluginProperties;
 use RyanHellyer\UniqueHeaders\AdminModule;
 use RyanHellyer\UniqueHeaders\AttachmentHelper;
 use RyanHellyer\UniqueHeaders\DisplayModule;

--- a/index.php
+++ b/index.php
@@ -42,6 +42,32 @@ if (! file_exists($autoloader)) {
 }
 require_once $autoloader;
 
+// Fallback: if the Composer autoload runtime is missing (e.g. stripped from
+// a production zip), register PSR-4 mappings for scoped dependencies directly.
+if (! interface_exists('RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\Module\\Module')) {
+    spl_autoload_register(static function (string $class): void {
+        $prefixes = [
+            'RyanHellyer\\UniqueHeaders\\Vendor\\Psr\\Container\\'
+                => __DIR__ . '/vendor/psr/container/src/',
+            'RyanHellyer\\UniqueHeaders\\Vendor\\Inpsyde\\Modularity\\'
+                => __DIR__ . '/vendor/inpsyde/modularity/src/',
+            'RyanHellyer\\UniqueHeaders\\'
+                => __DIR__ . '/src/',
+        ];
+        foreach ($prefixes as $prefix => $baseDir) {
+            $len = strlen($prefix);
+            if (strncmp($prefix, $class, $len) !== 0) {
+                continue;
+            }
+            $file = $baseDir . str_replace('\\', '/', substr($class, $len)) . '.php';
+            if (file_exists($file)) {
+                require $file;
+                return;
+            }
+        }
+    });
+}
+
 $helper = new AttachmentHelper();
 
 $properties = PluginProperties::new(__FILE__);

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 Plugin Name: Unique Headers
 Plugin URI: https://geek.hellyer.kiwi/plugins/unique-headers/
 Description: Unique Headers
-Version: 2.0.1
+Version: 2.1.1
 Author: Ryan Hellyer
 Author URI: https://geek.hellyer.kiwi/
 License: GPLv2 or later

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ parameters:
     paths:
         - src/
         - index.php
+    scanDirectories:
+        - vendor/psr/container/src
+        - vendor/inpsyde/modularity/src
 
 includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === Unique Headers ===
 Contributors: ryanhellyer
-Tags: custom-header, header, headers, images, page, post, plugin, image, images, categories, gallery, media, header-image, header-images, taxonomy, tag, category, posts, pages, taxonomies, post, page, unique, custom
+Tags: custom-header, header-images, taxonomy, media, attachments
 Donate link: https://geek.hellyer.kiwi/donate/
 Requires at least: 4.3
 Tested up to: 7.0
+License: GPLv2 or later
 Stable tag: 2.1
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,15 +5,13 @@ Donate link: https://geek.hellyer.kiwi/donate/
 Requires at least: 4.3
 Tested up to: 7.0
 License: GPLv2 or later
-Stable tag: 2.1
+Stable tag: 2.1.1
 
-
-
-Adds the ability to use unique custom header images on individual pages, posts or categories or tags.
-
-This plugin has been actively maintained since 2012 and is used on over 20,000 websites worldwide.
+Add unique custom header images to individual pages, posts, categories, or tags.
 
 == Description ==
+
+This plugin has been actively maintained since 2012 and is used on over 20,000 websites worldwide.
 
 = Features =
 The <a href="https://geek.hellyer.kiwi/products/unique-headers/">Unique Headers Plugin</a> adds a custom header image box to the post/page edit screen. You can use this to upload a unique header image for that post, or use another image from your WordPress media library. When you view that page on the front-end of your site, the default header image for your site will be replaced by the unique header you selected.
@@ -91,6 +89,10 @@ Yes. Just send me a message via <a href="https://ryan.hellyer.kiwi/contact/">my 
 
 
 == Changelog ==
+
+= 2.1.1 (2026-05-07) =
+* Fixing version number
+* Shortening readme description to meet WordPress.org requirements
 
 = 2.1 (2026-05-07) =
 * Fixed PSR-4 container namespacing bug

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: custom-header, header, headers, images, page, post, plugin, image, images,
 Donate link: https://geek.hellyer.kiwi/donate/
 Requires at least: 4.3
 Tested up to: 7.0
-Stable tag: 2.0.1
+Stable tag: 2.1
 
 
 
@@ -90,6 +90,9 @@ Yes. Just send me a message via <a href="https://ryan.hellyer.kiwi/contact/">my 
 
 
 == Changelog ==
+
+= 2.1 (2026-05-07) =
+* Fixed PSR-4 container namespacing bug
 
 = 2.0.1 (2026-05-01) =
 * CI: restricted PHP version matrix to 8.4 and 8.5

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,20 @@
+<?php
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+    'prefix' => 'RyanHellyer\\UniqueHeaders\\Vendor',
+    'finders' => [
+        Finder::create()
+            ->files()
+            ->in('vendor/psr/container')
+            ->name('*.php'),
+        Finder::create()
+            ->files()
+            ->in('vendor/inpsyde/modularity')
+            ->name('*.php'),
+    ],
+    'exclude-namespaces' => [
+        'Composer',
+    ],
+];

--- a/src/AdminModule.php
+++ b/src/AdminModule.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace RyanHellyer\UniqueHeaders;
 
-use Inpsyde\Modularity\Module\ExecutableModule;
-use Psr\Container\ContainerInterface;
+use RyanHellyer\UniqueHeaders\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
+use RyanHellyer\UniqueHeaders\Vendor\Psr\Container\ContainerInterface;
 
 class AdminModule implements ExecutableModule
 {

--- a/src/DisplayModule.php
+++ b/src/DisplayModule.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace RyanHellyer\UniqueHeaders;
 
-use Inpsyde\Modularity\Module\ExecutableModule;
-use Psr\Container\ContainerInterface;
+use RyanHellyer\UniqueHeaders\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
+use RyanHellyer\UniqueHeaders\Vendor\Psr\Container\ContainerInterface;
 
 class DisplayModule implements ExecutableModule
 {

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace RyanHellyer\UniqueHeaders\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
+use RyanHellyer\UniqueHeaders\Vendor\Psr\Container\ContainerInterface;
 use RyanHellyer\UniqueHeaders\AdminModule;
 use RyanHellyer\UniqueHeaders\AttachmentHelper;
 use RyanHellyer\UniqueHeaders\DisplayModule;


### PR DESCRIPTION
## Summary

Fix PSR-4 container namespacing bug by adding the missing autoload path for the `RyanHellyer\UniqueHeaders\` namespace, and release as version 2.1. This fixes bugs relating to plugin incompatibilities with plugins running older versions of the PSR container system.

## Changes

- **feat(build):** Add autoload path for `RyanHellyer\UniqueHeaders\` to `src/` in `build.sh` — the production autoloader was missing this entry, causing class resolution failures in the built artifact.
- **docs:** Add 2.1 changelog entry in `README.md` and `readme.txt`, and update stable tag to `2.1`.
