### PR TITLE
Fix/video header bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ If you would like to pay for assistance, additional features to be added to the 
 
 ### 2.1.3 - 2026-05-10
 
-* Fix: Resolved issue where custom header images would not display on WooCommerce product category pages due to taxonomy caching at plugin init time
-* Fix: Restored ability to upload video headers in the customizer
+* Resolved issue where custom header images would not display on WooCommerce product category pages due to taxonomy caching at plugin init time
+* Restored ability to upload video headers in the customizer
 
 ### 2.1.2 - 2026-05-08
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ If you would like to pay for assistance, additional features to be added to the 
 
 ## Changelog
 
+### 2.1.3 - 2026-05-10
+
+* Fix: Resolved issue where custom header images would not display on WooCommerce product category pages due to taxonomy caching at plugin init time
+* Fix: Restored ability to upload video headers in the customizer
+
+### 2.1.2 - 2026-05-08
+
+* Fix: Removed strict string type declarations from postHeaderImageFilter and taxonomyHeaderImageFilter to prevent TypeError when WordPress Customizer passes an array through the theme_mod_header_image filter
+
 ### 2.1.1 - 2026-05-07
 
 * Fixing version number

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 Plugin Name: Unique Headers
 Plugin URI: https://geek.hellyer.kiwi/plugins/unique-headers/
 Description: Unique Headers
-Version: 2.1.2
+Version: 2.1.3
 Author: Ryan Hellyer
 Author URI: https://geek.hellyer.kiwi/
 License: GPLv2 or later

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 Plugin Name: Unique Headers
 Plugin URI: https://geek.hellyer.kiwi/plugins/unique-headers/
 Description: Unique Headers
-Version: 2.1.1
+Version: 2.1.2
 Author: Ryan Hellyer
 Author URI: https://geek.hellyer.kiwi/
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -91,8 +91,8 @@ Yes. Just send me a message via <a href="https://ryan.hellyer.kiwi/contact/">my 
 == Changelog ==
 
 = 2.1.3 (2026-05-10) =
-* Fix: Resolved issue where custom header images would not display on WooCommerce product category pages due to taxonomy caching at plugin init time
-* Fix: Restored ability to upload video headers in the customizer
+* Resolved issue where custom header images would not display on WooCommerce product category pages due to taxonomy caching at plugin init time
+* Restored ability to upload video headers in the customizer
 
 = 2.1.2 (2026-05-08) =
 * Fix: Removed strict string type declarations from postHeaderImageFilter and taxonomyHeaderImageFilter to prevent TypeError when WordPress Customizer passes an array through the theme_mod_header_image filter

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://geek.hellyer.kiwi/donate/
 Requires at least: 4.3
 Tested up to: 7.0
 License: GPLv2 or later
-Stable tag: 2.1.1
+Stable tag: 2.1.2
 
 Add unique custom header images to individual pages, posts, categories, or tags.
 
@@ -89,6 +89,9 @@ Yes. Just send me a message via <a href="https://ryan.hellyer.kiwi/contact/">my 
 
 
 == Changelog ==
+
+= 2.1.2 (2026-05-08) =
+* Fix: Removed strict string type declarations from postHeaderImageFilter and taxonomyHeaderImageFilter to prevent TypeError when WordPress Customizer passes an array through the theme_mod_header_image filter
 
 = 2.1.1 (2026-05-07) =
 * Fixing version number

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://geek.hellyer.kiwi/donate/
 Requires at least: 4.3
 Tested up to: 7.0
 License: GPLv2 or later
-Stable tag: 2.1.2
+Stable tag: 2.1.3
 
 Add unique custom header images to individual pages, posts, categories, or tags.
 
@@ -89,6 +89,10 @@ Yes. Just send me a message via <a href="https://ryan.hellyer.kiwi/contact/">my 
 
 
 == Changelog ==
+
+= 2.1.3 (2026-05-10) =
+* Fix: Resolved issue where custom header images would not display on WooCommerce product category pages due to taxonomy caching at plugin init time
+* Fix: Restored ability to upload video headers in the customizer
 
 = 2.1.2 (2026-05-08) =
 * Fix: Removed strict string type declarations from postHeaderImageFilter and taxonomyHeaderImageFilter to prevent TypeError when WordPress Customizer passes an array through the theme_mod_header_image filter

--- a/src/DisplayModule.php
+++ b/src/DisplayModule.php
@@ -43,8 +43,16 @@ class DisplayModule implements ExecutableModule
         return true;
     }
 
-    public function postHeaderImageFilter(string $url): string
+    /**
+     * @param string|array<mixed> $url
+     * @return string|array<mixed>
+     */
+    public function postHeaderImageFilter($url)
     {
+        if (!is_string($url)) {
+            return $url;
+        }
+
         if (!is_single() && !is_page() && !is_home()) {
             return $url;
         }
@@ -74,8 +82,16 @@ class DisplayModule implements ExecutableModule
         return $this->setAttachmentData($data, $this->attachmentHelper->getId($postId, $this->nameUnderscores));
     }
 
-    public function taxonomyHeaderImageFilter(string $url): string
+    /**
+     * @param string|array<mixed> $url
+     * @return string|array<mixed>
+     */
+    public function taxonomyHeaderImageFilter($url)
     {
+        if (!is_string($url)) {
+            return $url;
+        }
+
         $taxId = $this->getCurrentTaxonomyId();
         if (!$taxId) {
             return $url;

--- a/src/DisplayModule.php
+++ b/src/DisplayModule.php
@@ -13,9 +13,6 @@ class DisplayModule implements ExecutableModule
     private string $name = 'custom-header-image';
     private string $nameUnderscores;
 
-    /** @var array<string, string> */
-    private array $taxonomies = [];
-
     public function __construct(AttachmentHelper $attachmentHelper)
     {
         $this->attachmentHelper = $attachmentHelper;
@@ -34,7 +31,6 @@ class DisplayModule implements ExecutableModule
         add_filter('theme_mod_header_image_data', [$this, 'postModifyHeaderImageData']);
 
         if (function_exists('get_term_meta')) {
-            $this->taxonomies = get_taxonomies(['public' => true]);
             add_action('admin_init', [$this, 'addTaxonomyFields']);
             add_filter('theme_mod_header_image', [$this, 'taxonomyHeaderImageFilter'], 5);
             add_filter('theme_mod_header_image_data', [$this, 'taxonomyModifyHeaderImageData']);
@@ -167,7 +163,7 @@ class DisplayModule implements ExecutableModule
             return;
         }
 
-        foreach ($this->taxonomies as $taxonomy) {
+        foreach (get_taxonomies(['public' => true]) as $taxonomy) {
             add_action($taxonomy . '_edit_form_fields', [$this, 'extraFields'], 1);
             add_action('edit_' . $taxonomy, [$this, 'storeTaxonomyData']);
         }
@@ -264,7 +260,7 @@ class DisplayModule implements ExecutableModule
         }
 
         if (is_tag() || is_tax()) {
-            foreach ($this->taxonomies as $taxonomy) {
+            foreach (get_taxonomies(['public' => true]) as $taxonomy) {
                 if ($taxonomy === 'category') {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Fixes video header support and WooCommerce product category header image display in Unique Headers 2.1.3.

## Changes

- **Fix: Video header support restored** — Removed strict `string` type declarations from `postHeaderImageFilter()` and `taxonomyHeaderImageFilter()` in `src/DisplayModule.php`. The WordPress Customizer passes an array through the `theme_mod_header_image` filter when a video header is set, causing a `TypeError`. Loosened type hints and added early returns for non-string input to preserve existing behavior for image headers while allowing video headers to work. (#7e238eb, #8d67499)

- **Fix: WooCommerce product category header images** — Moved taxonomy fetching from constructor-time property initialization to inline `get_taxonomies()` calls in `addTaxonomyFields()` and `getCurrentTaxonomyId()`. Previously, taxonomies were cached in the `$taxonomies` property at plugin init time, before WooCommerce had registered its product categories. This caused product category pages to never match a taxonomy, so custom header images were never displayed. (#4248dbb)

- **Version bump** — 2.1.1 → 2.1.3 with corresponding changelog entries in `README.md` and `readme.txt`. (#5864ad7)
